### PR TITLE
Add fqid to stage types

### DIFF
--- a/src/extensions/registry.js
+++ b/src/extensions/registry.js
@@ -8,7 +8,6 @@ const EXT_PATH = process.cwd() + '/node_modules/mc-ext-*'
 let registry = {
 
   _extensions: {},
-  _stageTypes: [],
   _typesByFqids: {},
 
   /**
@@ -31,7 +30,6 @@ let registry = {
 
     // Reset all of our internal registry pieces
     this._extensions = {}
-    this._stageTypes = []
     this._typesByFqids = {}
 
     // Reload the modules
@@ -72,7 +70,6 @@ let registry = {
         // Register the stage as vendor.extension_id.stages.example
         let fqid = module.vendor + '.' + module.id + '.stages.' + st.id
         this._typesByFqids[fqid] = st
-        this._stageTypes.push(st)
 
       })
     }
@@ -99,7 +96,16 @@ let registry = {
    * @return {Array}
    */
   getStageTypes: function getStageTypes() {
-    return this._stageTypes
+    let stages = []
+
+    for (let fqid in this._typesByFqids) {
+      // Shallow clone so we don't mutate the stage object
+      let stage = Object.assign({}, this._typesByFqids[fqid])
+        stage.fqid = fqid
+        stages.push(stage)
+    }
+
+    return stages
   }
 
 }

--- a/src/extensions/registry.js
+++ b/src/extensions/registry.js
@@ -63,13 +63,13 @@ let registry = {
 
     if (Array.isArray(module.stages)) {
 
-      module.stages.forEach(st => {
+      module.stages.forEach(stage => {
 
         // TODO: validate stage type
 
         // Register the stage as vendor.extension_id.stages.example
-        let fqid = module.vendor + '.' + module.id + '.stages.' + st.id
-        this._typesByFqids[fqid] = st
+        let fqid = module.vendor + '.' + module.id + '.stages.' + stage.id
+        this._typesByFqids[fqid] = stage
 
       })
     }

--- a/src/extensions/registry.js
+++ b/src/extensions/registry.js
@@ -101,8 +101,8 @@ let registry = {
     for (let fqid in this._typesByFqids) {
       // Shallow clone so we don't mutate the stage object
       let stage = Object.assign({}, this._typesByFqids[fqid])
-        stage.fqid = fqid
-        stages.push(stage)
+      stage.fqid = fqid
+      stages.push(stage)
     }
 
     return stages


### PR DESCRIPTION
Instead of maintaining to sets of references to stage types. I've changed the `getStageTypes` to build the array stage types on execution. I'm also adding the `fqid` to each stage, this is necessary for the UI so it can use it when creating a new stage config.

- Also changed `st` variable to `stage` so it's more explicit to what it is.