### PR TITLE
Updates to patch basic response

### DIFF
--- a/src/api/controllers/basic-response-helper.js
+++ b/src/api/controllers/basic-response-helper.js
@@ -65,6 +65,13 @@ module.exports = {
     })
   },
 
+  /**
+   * Patch a (single) record in a table
+   *
+   * @param req
+   * @param res
+   * @param table
+   */
   patchRespond: (req, res, table) => {
     if (req.params.id) {
       connection

--- a/src/api/controllers/basic-response-helper.js
+++ b/src/api/controllers/basic-response-helper.js
@@ -73,11 +73,22 @@ module.exports = {
    * @param table
    */
   patchRespond: (req, res, table) => {
+
+    let changes = req.body
+
+    // Don't allow ID to be changed
+    if (typeof changes.id !== 'undefined') {
+      delete changes.id
+    }
+
+    // Append a updated_at date
+    changes.updated_at = new Date()
+
     if (req.params.id) {
       connection
         .table(table)
         .where('id', req.params.id)
-        .update(req.body)
+        .update(changes)
         .then(item => {
           logger.log(item)
           res.status(200).send({message: 'Updated: ' + req.params.id})


### PR DESCRIPTION
- Protects the `id` field
- Automatically appends `updated_at`. NOTE: this may break things for tables without an updated_at column.