### PR TITLE
Set workers to have infinite timeout for messages

### DIFF
--- a/src/workers/worker.js
+++ b/src/workers/worker.js
@@ -12,6 +12,7 @@ let RSMQWorker = require('rsmq-worker')
 module.exports = (function() {
   return function(name) {
     let worker = new RSMQWorker(name, {
+      timeout: 0,
       redisPrefix: 'mission_control',
       host: process.env.REDIS_HOST,
       port: process.env.REDIS_PORT


### PR DESCRIPTION
Was having issues with long running process for packer command execution. Message would timeout and it would start another process to handle the message while existing one continued.

Ultimately we might need to handle timeouts more efficiently. If this becomes a problem, the best place to issue timeouts will most likely be in the `Job` not the worker.