### PR TITLE
Stage options

### DIFF
--- a/src/api/controllers/basic-response-helper.js
+++ b/src/api/controllers/basic-response-helper.js
@@ -141,6 +141,9 @@ module.exports = {
     // Create a new object from the incoming data
     let item = req.body
 
+    // Prevent null options for stages
+    item.options = item.options || {}
+
     // Protect the ID field by not allowing the user to specify it
     delete item.id
 
@@ -148,18 +151,27 @@ module.exports = {
     item.created_at = new Date()
     item.updated_at = new Date()
 
-    connection.insert(item, 'id').into(table).then((id) => {
+    connection
+      .table(table)
+      .insert(parseParams(item), 'id')
+      .then(id => {
 
-      connection.table(table).where('id', id).first().then((item) => {
-        res.status(201).send({data: item})
-      }).catch(err => {
+        connection
+          .table(table)
+          .where('id', id)
+          .first()
+          .then(item => {
+            res.status(201).send({data: item})
+          })
+          .catch(err => {
+            logger.error(err)
+            res.status(500).send({message: 'An error occurred.'})
+          })
+
+      })
+      .catch(err => {
         logger.error(err)
         res.status(500).send({message: 'An error occurred.'})
       })
-
-    }).catch(err => {
-      logger.error(err)
-      res.status(500).send({message: 'An error occurred.'})
-    })
   }
 }

--- a/src/api/controllers/basic-response-helper.js
+++ b/src/api/controllers/basic-response-helper.js
@@ -141,9 +141,6 @@ module.exports = {
     // Create a new object from the incoming data
     let item = req.body
 
-    // Prevent null options for stages
-    item.options = item.options || {}
-
     // Protect the ID field by not allowing the user to specify it
     delete item.id
 

--- a/src/api/controllers/stages.js
+++ b/src/api/controllers/stages.js
@@ -8,6 +8,10 @@ let connection = require('../../db/connection')
 module.exports = {
 
   setStageConfig: function setStageConfig(req, res) {
+    // Prevent null for stages options/outputmap
+    req.body.options = req.body.options || {}
+    req.body.output_map = req.body.output_map || {}
+
     basic.insertRespond(req, res, 'pipeline_stage_configs')
   },
 

--- a/src/api/controllers/stages.js
+++ b/src/api/controllers/stages.js
@@ -40,14 +40,7 @@ module.exports = {
       .then(items => {
         res.status(200).send({
           data: items.map(item => {
-            if (typeof item.output_map !== 'string' || item.output_map.substr(0, 1) !== '{') {
-              item.output_map = '{}'
-            }
             item.output_map = JSON.parse(item.output_map)
-
-            if (typeof item.options !== 'string' || item.options.substr(0, 1) !== '{') {
-              item.options = '{}'
-            }
             item.options = JSON.parse(item.options)
             return item
           })


### PR DESCRIPTION
Ensures 3 things:

- parameters are parsed for objects and stringified before insert
- stage config posts has a `options` property
- stage config posts has a `output_map` property

This relies on [110](https://github.com/space-race/mc-core/pull/111) to ensure timestamps don't get stringified.