### PR TITLE
Fix for timestamp bug

### DIFF
--- a/src/workers/pipeline/job.js
+++ b/src/workers/pipeline/job.js
@@ -111,7 +111,7 @@ module.exports = class Job {
 
           // Check if an input was provided. If so, use that, otherwise, use the default value
           if (typeof this.pipeline.input[key] !== 'undefined') {
-            initialVariableValues[key] = this.pipeline.input[key]
+            initialVariableValues[key] = this.tokenResolver.process(this.pipeline.input[key])
           } else {
             initialVariableValues[key] = this.tokenResolver.process(variable.default_value)
           }


### PR DESCRIPTION
Fixes #139. For input provided by the user (to start a pipeline execution), we now parse tokens like `{[ mc.timestamp() ]}`.