### PR TITLE
Workspace directories

### DIFF
--- a/src/workers/pipeline/job.js
+++ b/src/workers/pipeline/job.js
@@ -82,7 +82,7 @@ module.exports = class Job {
       let initialVariableValues = {}
 
       this.tokenResolver = new TokenResolver()
-      //this.tokenResolver.setKey('workspace_path', '') // TODO // {[ mc.workspace_path ]}
+      this.tokenResolver.setKey('workspace_path', '')
       this.tokenResolver.setKey('webhook', this.pipeline.webhook_data)
 
       this.pipeline.config.variables.forEach(variable => {

--- a/src/workers/pipeline/job.js
+++ b/src/workers/pipeline/job.js
@@ -1,5 +1,8 @@
 'use strict'
 
+let fs = require('fs')
+let path = require('path')
+let exec = require('child_process').exec
 let domain = require('domain')
 let logger = require('tracer').colorConsole()
 let Pipeline = require('../../core/pipelines/pipeline')
@@ -82,7 +85,7 @@ module.exports = class Job {
       let initialVariableValues = {}
 
       this.tokenResolver = new TokenResolver()
-      this.tokenResolver.setKey('workspace_path', '')
+      this.tokenResolver.setKey('workspace_path', this.workspacePath)
       this.tokenResolver.setKey('webhook', this.pipeline.webhook_data)
 
       this.pipeline.config.variables.forEach(variable => {
@@ -133,6 +136,55 @@ module.exports = class Job {
 
   }
 
+  setUpWorkspaceDirectory() {
+
+    logger.debug('setUpWorkspaceDirectory() promise registered')
+
+    return new Promise((resolve, reject) => {
+
+      logger.debug('setUpWorkspaceDirectory() promise running')
+
+      let baseDir = process.env.WORKSPACES_DIR || './storage/workspaces/'
+      let fullQualifiedBaseDir = path.resolve(baseDir)
+      let workspaceDir = '/pipeline_execution_' + this.pipeline.id
+      this.workspacePath = fullQualifiedBaseDir + workspaceDir
+
+      fs.mkdir(this.workspacePath, (err) => {
+        if (err) {
+          logger.error('workspace directory could not be created')
+          logger.error(err)
+          reject()
+        } else {
+          resolve()
+        }
+      })
+
+    })
+
+  }
+
+  tearDownWorkspaceDirectory() {
+    return new Promise((resolve) => {
+
+      logger.debug('tearing down workspace dir')
+
+      let command = 'rm -rf ' + this.workspacePath
+
+      exec(command, (err) => {
+
+        if (err) {
+          logger.error(err)
+        }
+
+        let title = (err) ? 'Workspace directory could not be deleted' : 'Workspace directory deleted'
+        let snippet = 'Path:\n' + this.workspacePath
+        this.pipeline.log('mc.basics.logs.snippet', title, [snippet])
+
+        resolve()
+      })
+    })
+  }
+
   /**
    * Run the pipeline execution
    */
@@ -144,19 +196,41 @@ module.exports = class Job {
 
       logger.debug('run() promise executing...')
 
-      // Clone the stage configurations to execute
-      this.stagesRemaining = this.pipeline.config.stageConfigs.slice(0)
+      this.setUpWorkspaceDirectory().then(() => {
 
-      this.executeNextStage(() => {
-        if (this.anyStageHasFailed) {
-          this.pipeline.fail().then(() => {
-            resolve()
-          })
-        } else {
-          this.pipeline.succeed().then(() => {
+        // log error to pipeline execution logs
+        let message = 'Path:\n' + this.workspacePath
+        this.pipeline.log('mc.basics.logs.snippet', 'Workspace directory created', [message])
+
+        // Clone the stage configurations to execute
+        this.stagesRemaining = this.pipeline.config.stageConfigs.slice(0)
+
+        let onComplete = () => {
+          this.tearDownWorkspaceDirectory().then(() => {
             resolve()
           })
         }
+
+        this.executeNextStage(() => {
+          if (this.anyStageHasFailed) {
+            this.pipeline.fail().then(onComplete)
+          } else {
+            this.pipeline.succeed().then(onComplete)
+          }
+        })
+
+      }).catch(() => {
+
+        // If we could not create the directory...
+
+        // log error to pipeline execution logs
+        let message = 'Path:\n' + this.workspacePath
+        this.pipeline.log('mc.basics.logs.snippet', 'Workspace directory could not created', [message])
+
+        // Mark the pipeline as failed and resolve
+        this.pipeline.fail().then(() => {
+          resolve()
+        })
       })
 
     })


### PR DESCRIPTION
- [x] A workspace dir should be set in .env
- [x] The environment variable should be added in the mission control `.env.example`
- [x] A workspace directory should be created on pipeline execution
- [x] A workspace directory should be torn down on pipeline execution completion
- [x] If a workspace directory creation fails, the job should fail.
- [x] Workspace directory path should be provided as a variable to the jobs as workspace_path

Also, see related issue [space-race/mc-ext-basics/#10](https://github.com/space-race/mc-ext-basics/issues/10).

Closes #148.