### PR TITLE
Coverage

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,5 @@ extensions/**
 logs/**
 storage/**
 ui-build/**
+coverage/**
+.nyc_output/**

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage/
 .DS_Store
 .env
 npm-debug.log
+.coveralls.yml

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ node_modules/
 build/
 ui-build/
 logs/
+coverage/
+.nyc_output/
 
 # Files
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
   ],
   "main": "build/server.js",
   "scripts": {
-    "test": "./node_modules/.bin/eslint . && NODE_ENV=test ./node_modules/.bin/tape 'test/**/spec.*.js' | ./node_modules/.bin/tap-spec",
+    "test": "NODE_ENV=test ./node_modules/.bin/tap test/**/spec.*.js",
+    "lint": "./node_modules/.bin/eslint src",
+    "cover": "npm test -- --cov --coverage-report=lcov",
+    "release": "npm run lint && npm run cover",
     "postinstall": "node_modules/.bin/gulp"
   },
   "author": "Andy Fleming <andy@zesty.io>",
@@ -89,6 +92,7 @@
     "mock-express-response": "0.1.1",
     "sinon": "1.17.2",
     "supertest": "1.1.0",
+    "tap": "5.4.2",
     "tap-spec": "4.1.1",
     "tape": "4.2.2"
   }


### PR DESCRIPTION
Adds [node-tap](http://www.node-tap.org/) as a dependency since it contains coverage via `nyc` using `istanbul`. This allows easily adding code coverage for the existing tap tests. Ignores generated files from coverage.

Simplified npm scripts by separating the different parts of testing to individual scripts; `lint`, `test`, `cover` 