### PR TITLE
Ensures setup uses the database port specified in .env file

### DIFF
--- a/src/cli/commands/setup.js
+++ b/src/cli/commands/setup.js
@@ -70,7 +70,7 @@ module.exports = () => {
       host: process.env.DB_HOST,
       user: process.env.DB_USER,
       password: process.env.DB_PASS,
-      database: process.env.DB_NAME
+      database: process.env.DB_NAME,
       port: process.env.DB_PORT
     }
   })

--- a/src/cli/commands/setup.js
+++ b/src/cli/commands/setup.js
@@ -224,7 +224,7 @@ module.exports = () => {
 
   function enterPassword(user) {
     return new Promise((resolve) => {
-      promptly.prompt('Enter your Mission Control password:', (err, password) => {
+      promptly.prompt('Enter your Mission Control password:', {silent: true}, (err, password) => {
         if (err) {
           console.log(err)
         }

--- a/src/cli/commands/setup.js
+++ b/src/cli/commands/setup.js
@@ -50,6 +50,9 @@ module.exports = () => {
   if (!process.env.DB_HOST) {
     console.log(colors.yellow('Your .env file is missing the MySQL DB_HOST'))
   }
+  if (!process.env.DB_PORT) {
+    console.log(colors.yellow('Your .env file is missing the MySQL DB_PORT'))
+  }
   if (!process.env.DB_NAME) {
     console.log(colors.yellow('Your .env file is missing the MySQL DB_NAME'))
   }
@@ -68,6 +71,7 @@ module.exports = () => {
       user: process.env.DB_USER,
       password: process.env.DB_PASS,
       database: process.env.DB_NAME
+      port: process.env.DB_PORT
     }
   })
 


### PR DESCRIPTION
If you specify a port outside of the default mysql port, it will not be used during setup which causes the setup to error.