### PR TITLE
Explicitly sets ON UPDATE for `updated_at`

### DIFF
--- a/src/db/timestamps-schema.js
+++ b/src/db/timestamps-schema.js
@@ -3,6 +3,6 @@ module.exports = (knex, table) => {
   // any other timestamps to ensure `updated_at`
   // is set with `on update CURRENT_TIMESTAMP`
   // TODO file a bug? could be solved here; https://github.com/tgriesser/knex/issues/547
-  table.timestamp('updated_at').notNullable()
+  table.timestamp('updated_at').notNullable().defaultTo(knex.raw('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'))
   table.timestamp('created_at').notNullable().defaultTo(knex.fn.now())
 }


### PR DESCRIPTION
Docs suggested Mysql 5.6+, but on Mysql 5.7 I was still getting `Field 'updated_at' doesn't have a default value` errors without this change.